### PR TITLE
Added ansible role for configuring openshift templates

### DIFF
--- a/roles/configure-openshift-templates/defaults/main.yml
+++ b/roles/configure-openshift-templates/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+default_openshift_project_name: "openshift"

--- a/roles/configure-openshift-templates/files/example-image-stream-php.json
+++ b/roles/configure-openshift-templates/files/example-image-stream-php.json
@@ -1,0 +1,62 @@
+{
+  "kind": "ImageStreamList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "php"
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": {
+              "description": "Build and run PHP applications",
+              "iconClass": "icon-php",
+              "tags": "builder,php",
+              "supports":"php",
+              "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+            },
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "5.6"
+            }
+          },
+          {
+            "name": "5.5",
+            "annotations": {
+              "description": "Build and run PHP 5.5 applications",
+              "iconClass": "icon-php",
+              "tags": "builder,php",
+              "supports":"php:5.5,php",
+              "version": "5.5",
+              "sampleRepo": "https://github.com/openshift/cakephp-ex.git"              
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/openshift3/php-55-rhel7:latest"
+            }
+          },
+          {
+            "name": "5.6",
+            "annotations": {
+              "description": "Build and run PHP 5.6 applications",
+              "iconClass": "icon-php",
+              "tags": "builder,php",
+              "supports":"php:5.6,php",
+              "version": "5.6",
+              "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/rhscl/php-56-rhel7:latest"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/roles/configure-openshift-templates/files/example-php-template.json
+++ b/roles/configure-openshift-templates/files/example-php-template.json
@@ -1,0 +1,343 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "rht-labs-php-example",
+    "annotations": {
+      "description": "An example RHT Labs PHP application (based on cakephp) with no database",
+      "tags": "quickstart,php,cakephp",
+      "iconClass": "icon-php"
+    }
+  },
+  "labels": {
+    "template": "rht-labs-php-example"
+  },
+  "objects": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "annotations": {
+          "description": "Exposes and load balances the application pods"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "web",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "name": "${NAME}"
+        }
+      }
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}"
+      },
+      "spec": {
+        "host": "${APPLICATION_DOMAIN}",
+        "to": {
+          "kind": "Service",
+          "name": "${NAME}"
+        }
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "annotations": {
+          "description": "Keeps track of changes in the application image"
+        }
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "annotations": {
+          "description": "Defines how to build the application"
+        }
+      },
+      "spec": {
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "${SOURCE_REPOSITORY_URL}",
+            "ref": "${SOURCE_REPOSITORY_REF}"
+          },
+          "contextDir": "${CONTEXT_DIR}"
+        },
+        "strategy": {
+          "type": "Source",
+          "sourceStrategy": {
+            "from": {
+              "kind": "ImageStreamTag",
+              "namespace": "${NAMESPACE}",
+              "name": "php:5.6"
+            },
+            "env":  [
+              {
+                  "name": "COMPOSER_MIRROR",
+                  "value": "${COMPOSER_MIRROR}"
+              }
+            ]
+          }
+        },
+        "output": {
+          "to": {
+            "kind": "ImageStreamTag",
+            "name": "${NAME}:latest"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ImageChange"
+          },
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "GitHub",
+            "github": {
+              "secret": "${GITHUB_WEBHOOK_SECRET}"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "annotations": {
+          "description": "Defines how to deploy the application server"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Rolling"
+        },
+        "triggers": [
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "rht-labs-php-example"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "${NAME}:latest"
+              }
+            }
+          },
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "${NAME}"
+        },
+        "template": {
+          "metadata": {
+            "name": "${NAME}",
+            "labels": {
+              "name": "${NAME}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "rht-labs-php-example",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 8080
+                  }
+                ],
+                "readinessProbe": {
+                  "timeoutSeconds": 3,
+                  "initialDelaySeconds": 3,
+                  "httpGet": {
+                    "path": "/",
+                    "port": 8080
+                  }
+                },
+                "livenessProbe": {
+                    "timeoutSeconds": 3,
+                    "initialDelaySeconds": 30,
+                    "httpGet": {
+                        "path": "/",
+                        "port": 8080
+                    }
+                },
+                "env": [
+                  {
+                    "name": "DATABASE_SERVICE_NAME",
+                    "value": "${DATABASE_SERVICE_NAME}"
+                  },
+                  {
+                    "name": "DATABASE_ENGINE",
+                    "value": "${DATABASE_ENGINE}"
+                  },
+                  {
+                    "name": "DATABASE_NAME",
+                    "value": "${DATABASE_NAME}"
+                  },
+                  {
+                    "name": "DATABASE_USER",
+                    "value": "${DATABASE_USER}"
+                  },
+                  {
+                    "name": "DATABASE_PASSWORD",
+                    "value": "${DATABASE_PASSWORD}"
+                  },
+                  {
+                    "name": "CAKEPHP_SECRET_TOKEN",
+                    "value": "${CAKEPHP_SECRET_TOKEN}"
+                  },
+                  {
+                    "name": "CAKEPHP_SECURITY_SALT",
+                    "value": "${CAKEPHP_SECURITY_SALT}"
+                  },
+                  {
+                    "name": "CAKEPHP_SECURITY_CIPHER_SEED",
+                    "value": "${CAKEPHP_SECURITY_CIPHER_SEED}"
+                  },
+                  {
+                    "name": "OPCACHE_REVALIDATE_FREQ",
+                    "value": "${OPCACHE_REVALIDATE_FREQ}"
+                  }
+                ],
+		"resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		}
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAME",
+      "displayName": "Name",
+      "description": "The name assigned to all of the frontend objects defined in this template.",
+      "required": true,
+      "value": "rht-labs-php-example"
+    },
+    {
+      "name": "NAMESPACE",
+      "displayName": "Namespace",
+      "description": "The OpenShift Namespace where the ImageStream resides.",
+      "required": true,
+      "value": "openshift"
+    },
+    {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "required": true,
+      "value": "512Mi"
+    },
+    {
+      "name": "SOURCE_REPOSITORY_URL",
+      "displayName": "Git Repository URL",
+      "description": "The URL of the repository with your application source code.",
+      "required": true,
+      "value": "https://github.com/openshift/php-ex.git"
+    },
+    {
+      "name": "SOURCE_REPOSITORY_REF",
+      "displayName": "Git Reference",
+      "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+    },
+    {
+      "name": "CONTEXT_DIR",
+      "displayName": "Context Directory",
+      "description": "Set this to the relative path to your project if it is not in the root of your repository."
+    },
+    {
+      "name": "APPLICATION_DOMAIN",
+      "displayName": "Application Hostname",
+      "description": "The exposed hostname that will route to the CakePHP service, if left blank a value will be defaulted.",
+      "value": ""
+    },
+    {
+      "name": "GITHUB_WEBHOOK_SECRET",
+      "displayName": "GitHub Webhook Secret",
+      "description": "A secret string used to configure the GitHub webhook.",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{40}"
+    },
+    {
+      "name": "DATABASE_SERVICE_NAME",
+      "displayName": "Database Service Name"
+    },
+    {
+      "name": "DATABASE_ENGINE",
+      "displayName": "Database Engine",
+      "description": "Database engine: postgresql, mysql or sqlite (default)."
+    },
+    {
+      "name": "DATABASE_NAME",
+      "displayName": "Database Name"
+    },
+    {
+      "name": "DATABASE_USER",
+      "displayName": "Database User"
+    },
+    {
+      "name": "DATABASE_PASSWORD",
+      "displayName": "Database Password"
+    },
+    {
+      "name": "CAKEPHP_SECRET_TOKEN",
+      "displayName": "CakePHP Secret Token",
+      "description": "Set this to a long random string.",
+      "generate": "expression",
+      "from": "[\\w]{50}"
+    },
+    {
+      "name": "CAKEPHP_SECURITY_SALT",
+      "displayName": "CakePHP Security Salt",
+      "description": "Security salt for session hash.",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{40}"
+    },
+    {
+      "name": "CAKEPHP_SECURITY_CIPHER_SEED",
+      "displayName": "CakePHP Security Cipher Seed",
+      "description": "Security cipher seed for session hash.",
+      "generate": "expression",
+      "from": "[0-9]{30}"
+    },
+    {
+      "name": "OPCACHE_REVALIDATE_FREQ",
+      "displayName": "OPcache Revalidation Frequency",
+      "description": "How often to check script timestamps for updates, in seconds. 0 will result in OPcache checking for updates on every request.",
+      "value": "2"
+    },
+    {
+      "name": "COMPOSER_MIRROR",
+      "displayName": "Custom Composer Mirror URL",
+      "description": "The custom Composer mirror URL",
+      "value": ""
+    }
+  ]
+}

--- a/roles/configure-openshift-templates/tasks/main.yml
+++ b/roles/configure-openshift-templates/tasks/main.yml
@@ -28,11 +28,11 @@
     {{ openshift.common.client_binary }} delete imagestreams --all -n {{ openshift_project_name }}
   when: openshift_project_name|trim != ''
 
-- name: "Load Up Templates in {{ openshift_project_name }}"
+- name: "Load Up Templates in {{ openshift_target_project_name }}"
   command: >
     {{ openshift.common.client_binary }} create -f {{ template_file }} -n {{ openshift_target_project_name }}
 
-- name: "Load Up ImageStreams in {{ openshift_project_name }}"
+- name: "Load Up ImageStreams in {{ openshift_target_project_name }}"
   command: >
     {{ openshift.common.client_binary }} create -f {{ imagestreams_file }} -n {{ openshift_target_project_name }}
 

--- a/roles/configure-openshift-templates/tasks/main.yml
+++ b/roles/configure-openshift-templates/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: "Setting OpenShift Templates and ImageStreams Facts"
+  set_fact:
+    openshift_target_project_name: "{{ (openshift_project_name|trim == '') | ternary(default_openshift_project_name, openshift_project_name) }}"
+
+- name: Get all project names
+  command: >
+    {{ openshift.common.client_binary }} get projects
+  register: existing_openshift_projects
+
+- name: "Clean out old Templates in all namespaces/projects"
+  command: >
+    {{ openshift.common.client_binary }} delete templates --all -n {{ item.split(' ')[0] }}
+  with_items: "{{ existing_openshift_projects.stdout_lines }}"
+  
+- name: "Clean out old Templates in '{{ openshift_project_name }}' namespace"
+  command: >
+    {{ openshift.common.client_binary }} delete templates --all -n {{ openshift_project_name }}
+  when: openshift_project_name|trim != ''
+
+- name: "Clean out old ImageStreams in all namespaces/projects"
+  command: >
+    {{ openshift.common.client_binary }} delete imagestreams --all -n {{ item.split(' ')[0]}}
+  with_items: "{{ existing_openshift_projects.stdout_lines }}"
+  
+- name: "Clean out old ImageStreams in '{{ openshift_project_name }}' namespace"
+  command: >
+    {{ openshift.common.client_binary }} delete imagestreams --all -n {{ openshift_project_name }}
+  when: openshift_project_name|trim != ''
+
+- name: "Load Up Templates in {{ openshift_project_name }}"
+  command: >
+    {{ openshift.common.client_binary }} create -f {{ template_file }} -n {{ openshift_target_project_name }}
+
+- name: "Load Up ImageStreams in {{ openshift_project_name }}"
+  command: >
+    {{ openshift.common.client_binary }} create -f {{ imagestreams_file }} -n {{ openshift_target_project_name }}
+
+

--- a/roles/configure-openshift-templates/test/load-example.yml
+++ b/roles/configure-openshift-templates/test/load-example.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Load up example templates and image streams
+  hosts: localhost
+  vars:
+  - template_file: example-php-template.json
+  - imagestreams_file: example-image-stream-php.json
+  roles:
+  - openshift-defaults
+  - configure-openshift-templates


### PR DESCRIPTION
New ansible role to trim/customize templates and image streams

Example run:
1. Copy the content of `test` and `files` to top level directory 
2. Run one of the following two commands:
`ansible-playbook load-example.yml`
`ansible-playbook -v --extra-vars "openshift_project_name=<project_name>" load-example.yml`
The first one will update the default `openshift` project with the templates/image streams. The second command will clean out all existing templates/image streams and load up the new configuration into the specified project_name.

**NOTE**: A set of example files are provided in the `files` directory - these are based on the openshift example files and just included to have something to use for testing. These files should **NOT** be used for any official use as-is.
