### PR TITLE
Adding support for PVs and PVCs

### DIFF
--- a/roles/create-openshift-resources/README.md
+++ b/roles/create-openshift-resources/README.md
@@ -5,8 +5,23 @@ An ansible role that consumes the model defined in the [Open Innovation Labs Aut
 
 ## Testing
 
-The current tests are written against the [Red Hat Container Development Kit](http://developers.redhat.com/products/cdk/overview/) in order to increase portability. You'll need to make sure that ansible can ssh in to the vagrant image that serves the CDK. The simplest way to do this is to add the private key that vagrant generates to your local ssh agent. The below command is an example of how to do this is you are using libvirt as vagrant provider:
+### CDK
+Most of the tests are written against the [Red Hat Container Development Kit](http://developers.redhat.com/products/cdk/overview/) in order to increase portability. You'll need to make sure that ansible can ssh in to the vagrant image that serves the CDK. The simplest way to do this is to add the private key that vagrant generates to your local ssh agent. The below command is an example of how to do this is you are using libvirt as vagrant provider:
 
-    `ssh-add <your_vagrant_dir>/.vagrant/machines/default/libvirt/private_key`
+```
+  >> ssh-add <your_vagrant_dir>/.vagrant/machines/default/libvirt/private_key
+```
 
 At this point, the configuration in the [test inventory file](tests/inventory) and the tests prefixed with `cdk` should be to run the tests. If not, please open an issue and let us know.
+
+### OpenShift Environment
+For test that aren't a good fit for a CDK run, i.e.: need external / 3rd party resources, a real OpenShift environment can be used. As many of the roles part of the `ansible-stacks` implementations touches on cluster administration related areas, it's required that the user used is part of the `cluster-admins` role. For example, to run as the user **lisa** with password **mypassword!**, the following steps would be required:
+
+```
+  1. (as root) >> oadm policy add-cluster-role-to-user cluster-admin lisa
+  2. (as lisa) >> ansible-playbook -e 'openshift_username=lisa openshift_password=mypassword! [cleanup=yes]' <playbook>
+```
+
+**Notes** 
+  1. The first command to grant cluster-admin to the user is only needed to be done once per cluster for a user.
+  1. If the tests should do clean-up after execution, make sure to set the `cleanup` environment variable - i.e.: >> ansible-playbook -e 'cleanup=yes' <playbook>

--- a/roles/create-openshift-resources/tasks/configure_openshift_cluster.yml
+++ b/roles/create-openshift-resources/tasks/configure_openshift_cluster.yml
@@ -4,10 +4,16 @@
 
 - name: "Set Default Cluster Facts"
   set_fact:
+    openshift_persistent_volumes_present: false
     openshift_resources_present: false
     openshift_cluster: "{{ openshift_cluster_item }}" # http://docs.ansible.com/ansible/playbooks_loops.html#loops-and-includes-in-2-0
 
-- name: "Set Variable Cluster Facts"
+- name: "Set Variable openshift_persistent_volumes_present Fact"
+  set_fact:
+    openshift_persistent_volumes_present: true
+  when: openshift_cluster.persistent_volumes is defined and openshift_cluster.persistent_volumes != "" and openshift_cluster.persistent_volumes|length > 0
+
+- name: "Set Variable openshift_resources_present Facts"
   set_fact:
     openshift_resources_present: true
   when: openshift_cluster.openshift_resources is defined and openshift_cluster.openshift_resources != "" and openshift_cluster.openshift_resources|length > 0
@@ -30,6 +36,13 @@
     --insecure-skip-tls-verify=true --username={{ openshift_user }} --password={{ openshift_password }}
   changed_when: False
   when: openshift_resources_present == true
+
+- include: create_persistent_volumes.yml
+  with_items: '{{ openshift_cluster.persistent_volumes }}'
+  loop_control:
+    loop_var: persistent_volumes_item
+  static: no
+  when: openshift_persistent_volumes_present == true
 
 - include: create_openshift_resources.yml
   when: openshift_resources_present == true

--- a/roles/create-openshift-resources/tasks/create_app.yml
+++ b/roles/create-openshift-resources/tasks/create_app.yml
@@ -25,6 +25,7 @@
     environment_variables: ''
     environment_variables_string: ''
     is_fabric8_java_s2i: false
+    pvc_associations: false
 
 - name: "Set oc new-app friendly SCM with both SCM URL and SCM Ref"
   set_fact:
@@ -101,6 +102,11 @@
     is_fabric8_java_s2i: true
   when: app.labels.provider is defined and app.labels.provider == 'fabric8'
 
+- name: "Set Fact for Persistent Volume Claim Associations"
+  set_fact:
+    pvc_associations: true
+  when: app.pvc_associations is defined and app.pvc_associations != ''
+
 
 - name: "Determine if {{ app.name }} App Exists"
   command: >
@@ -135,6 +141,18 @@
 
 - include: fabric8_java_s2i_build.yml
   when: is_fabric8_java_s2i is defined and is_fabric8_java_s2i == true
+
+- name: "Add Volume to {{ app.name }}"
+  with_items: '{{ app.pvc_associations }}'
+  loop_control:
+    loop_var: volume_associations
+  command: >
+    {{ openshift.common.client_binary }} volume dc/{{ app.name }} --add \
+      --name={{ volume_associations.name }} \
+      --claim-name={{ volume_associations.claim_type.name }} \
+      --mount-path={{ volume_associations.mount_path }} \
+      -n {{ project.name }}
+  when: pvc_associations == true and get_app_name_result.rc != 0 and create_app_result.rc == 0
 
 - name: "Expose App: {{ app.name }}"
   command: >

--- a/roles/create-openshift-resources/tasks/create_persistent_volume_claims.yml
+++ b/roles/create-openshift-resources/tasks/create_persistent_volume_claims.yml
@@ -1,0 +1,40 @@
+---
+- name: "Set Basic Persistent Volume Claim Facts"
+  set_fact:
+    pvc: "{{ persistent_volume_claims_item }}"
+
+- name: Fail for Missing Persistent Volume Claim Parameters
+  fail: msg="This role requires persistent_volume_claims.{{ item }} be set and non empty"
+  when: pvc.{{ item }} is not defined or pvc.{{ item }} == ''
+  with_items:
+  - name
+  - access_modes
+  - storage
+
+- name: "Determine if {{ pvc.name }} Persistent Volume Claim Exists"
+  command: >
+     {{ openshift.common.client_binary }} get pvc {{ pvc.name }} -n {{ project.name }} -o json
+  register: get_pvc_name_result
+  failed_when: false
+  changed_when: false
+
+- name: "Use a unique temporary file to store the Persistent Volume Claim object"
+  command: mktemp
+  register: tempfile
+  when: get_pvc_name_result.rc != 0
+
+- name: "Prepare the object definition for the Persistent Volume Claim"
+  template:
+    src: pvc.j2
+    dest: "{{ tempfile.stdout }}"
+  when: get_pvc_name_result.rc != 0
+
+- name: "Create Persistent Volume Claim"
+  command: >
+    {{ openshift.common.client_binary }} create -f {{ tempfile.stdout }} -n {{ project.name }}
+  when: get_pvc_name_result.rc != 0
+
+- name: "Persistent Volume Claim temporary file clean-up"
+  file: path={{ tempfile.stdout }} state=absent  
+  when: get_pvc_name_result.rc != 0
+

--- a/roles/create-openshift-resources/tasks/create_persistent_volumes.yml
+++ b/roles/create-openshift-resources/tasks/create_persistent_volumes.yml
@@ -1,0 +1,42 @@
+---
+- name: "Set Basic Persistent Volume Facts"
+  set_fact:
+    pv: "{{ persistent_volumes_item }}"
+
+- name: Fail for Missing Persistent Volume Parameters
+  fail: msg="This role requires persistent_volumes.{{ item }} be set and non empty"
+  when: pv.{{ item }} is not defined or pv.{{ item }} == ''
+  with_items:
+  - name
+  - capacity
+  - access_modes
+  - nfs_path
+  - nfs_server
+
+- name: "Determine if {{ pv.name }} Persistent Volume Exists"
+  command: >
+     {{ openshift.common.client_binary }} get pv {{ pv.name }} -o json
+  register: get_pv_name_result
+  failed_when: false
+  changed_when: false
+
+- name: "Use a unique temporary file to store the Persistent Volume object"
+  command: mktemp
+  register: tempfile
+  when: get_pv_name_result.rc != 0
+
+- name: "Prepare the object definition for the Persistent Volume"
+  template:
+    src: pv.j2
+    dest: "{{ tempfile.stdout }}"
+  when: get_pv_name_result.rc != 0
+
+- name: "Create Persistent Volume"
+  command: >
+    {{ openshift.common.client_binary }} create -f {{ tempfile.stdout }}
+  when: get_pv_name_result.rc != 0
+
+- name: "Persistent Volume temporary file clean-up"
+  file: path={{ tempfile.stdout }} state=absent  
+  when: get_pv_name_result.rc != 0
+

--- a/roles/create-openshift-resources/tasks/create_project.yml
+++ b/roles/create-openshift-resources/tasks/create_project.yml
@@ -24,6 +24,11 @@
     role_bindings_present: true
   when: project.user_to_role is defined and project.user_to_role != "" and project.user_to_role|length > 0
 
+- name: "Set Variable persistent_volume_claims_present Fact"
+  set_fact:
+    persistent_volume_claims_present: true
+  when: project.persistent_volume_claims is defined and project.persistent_volume_claims != "" and project.persistent_volume_claims|length > 0
+
 - name: "Set Variable apps_present Fact"
   set_fact:
     apps_present: true
@@ -51,6 +56,13 @@
   loop_control:
     loop_var: role_binding_item
   when: role_bindings_present == true
+  static: no
+
+- include: create_persistent_volume_claims.yml
+  with_items: '{{ project.persistent_volume_claims }}'
+  loop_control:
+    loop_var: persistent_volume_claims_item
+  when: persistent_volume_claims_present == true
   static: no
 
 - include: create_app.yml

--- a/roles/create-openshift-resources/templates/pv.j2
+++ b/roles/create-openshift-resources/templates/pv.j2
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ pv.name }} 
+{% if pv.labels is defined and pv.labels != "" %} 
+  labels:
+{% for label in pv.labels %}
+    {{ label }}: {{ pv.labels[label] }}
+{% endfor %}
+{% endif %}
+spec:
+  capacity:
+    storage: {{ pv.capacity }}Gi 
+  accessModes:
+{% for mode in pv.access_modes %}
+  - {{ mode }} 
+{% endfor %}
+  nfs: 
+    path: {{ pv.nfs_path }}
+    server: {{ pv.nfs_server }}
+  persistentVolumeReclaimPolicy: {{ pv.reclaim_policy }}

--- a/roles/create-openshift-resources/templates/pvc.j2
+++ b/roles/create-openshift-resources/templates/pvc.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ pvc.name }}
+spec:
+  accessModes:
+{% for mode in pvc.access_modes %}
+    - {{ mode }}
+{% endfor %}
+  resources:
+    requests:
+      storage: {{ pvc.storage }}Gi
+{% if pvc.selector is defined and pvc.selector != "" %}
+  selector:
+    matchLabels:
+{% for label in pvc.selector.match_labels %}
+      {{ label }}: {{ pvc.selector.match_labels[label] }}
+{% endfor %}
+{% endif %}

--- a/roles/create-openshift-resources/tests/create_persistent_volume.yml
+++ b/roles/create-openshift-resources/tests/create_persistent_volume.yml
@@ -1,0 +1,33 @@
+---
+# This test covers the full feature set provided by the role
+
+- name: "Create test resources"
+  hosts: localhost
+
+  vars_files:
+    - vars/persistent_volume.json
+
+#  vars: # use the -e command line option to provide a valid username/password combo
+#    openshift_password: 
+#    openshift_user: 
+
+  roles:
+    - openshift-defaults
+    - create-openshift-resources
+
+# cleanup
+  post_tasks:
+  - name: "Remove project {{ item.name }}"
+    command: >
+      {{ openshift.common.client_binary }} delete project {{ item.name }}
+    when: '"{{ item.name }}" != "ci" and cleanup is defined and cleanup'
+    with_items: '{{ openshift_resources.projects }}'
+
+  - name: "Remove Persistent Volumes used for testing"
+    command: >
+      {{ openshift.common.client_binary }} delete pv {{ item.1.name }}
+    when: 'cleanup is defined and cleanup'
+    with_subelements: 
+    - "{{ openshift_clusters }}"
+    - persistent_volumes 
+

--- a/roles/create-openshift-resources/tests/vars/persistent_volume.json
+++ b/roles/create-openshift-resources/tests/vars/persistent_volume.json
@@ -1,0 +1,112 @@
+{
+	"openshift_clusters": [
+		{
+			"openshift_host_env": "10.1.2.2:8443",
+			"openshift_resources": {
+				"projects": [
+					{
+						"name": "pipeline-dev",
+						"display_name": "Pipeline - Dev",
+						"environment_type": "build",
+						"apps": [
+							{
+								"name": "jenkins",
+								"scm_url": "https://github.com/rht-labs/openshift-jenkins-s2i-config.git",
+								"scm_ref": "master",
+								"base_image": "jenkins",
+								"build_tool": "s2i",
+								"pvc_associations": [
+									{
+										"name": "pipeline-dev-env",
+										"mount_path": "/etc/pipeline-dev-env",
+										"claim_type": {
+											"kind": "claim",
+											"name": "pipeline-dev-env"
+										}
+									}
+								]
+							}
+						],
+						"persistent_volume_claims": [
+							{
+								"name": "pipeline-dev-env",
+								"access_modes": [
+									"ReadOnlyMany"
+								],
+								"storage": 1,
+								"selector": {
+									"match_labels": {
+										"pvc": "pipeline-dev-env"
+									}
+								}
+							}
+						]
+					},
+					{
+						"name": "pipeline-delivery",
+						"display_name": "Pipeline - Delivery",
+						"environment_type": "promotion",
+						"apps": [
+							{
+								"name": "jenkins",
+								"base_image": "jenkins",
+								"pvc_associations": [
+									{
+										"name": "pipeline-dev-env",
+										"mount_path": "/etc/pipeline-dev-env",
+										"claim_type": {
+											"kind": "claim",
+											"name": "pipeline-dev-env"
+										}
+									}
+								]
+							}
+						],
+						"persistent_volume_claims": [
+							{
+								"name": "pipeline-delivery-env",
+								"access_modes": [
+									"ReadOnlyMany"
+								],
+								"storage": 1,
+								"selector": {
+									"match_labels": {
+										"pvc": "pipeline-delivery-env"
+									}
+								}
+							}
+						]
+					}
+				]
+			},
+			"persistent_volumes": [
+				{
+					"name": "pipeline-dev-env",
+					"capacity": 1,
+					"access_modes": [
+						"ReadOnlyMany"
+					],
+					"nfs_path": "/export/dev-env",
+					"nfs_server": "nfs-server-goes-here.com",
+					"reclaim_policy": "Retain",
+					"labels": {
+						"pvc": "pipelin-dev-env"
+					}	
+				},
+				{
+					"name": "pipeline-delivery-env",
+					"capacity": 1,
+					"access_modes": [
+						"ReadOnlyMany"
+					],
+					"nfs_path": "/export/delivery-env",
+					"nfs_server": "nfs-server-goes-here.com",
+					"reclaim_policy": "Retain",
+					"labels": {
+						"pvc": "pipelin-delivery-env"
+					}	
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
#### What does this PR do?
- Support the creation of PVs at a cluster level
- Support the creation of PVCs at the project level
  - Support using (optional) labels to bind the correct PV with a PVC (new in OCP 3.3)
- Support associating PVCs with an applications
#### Which tests illustrate how this code works?

The `create_persistent_volume.yml` playbook in the tests directory
#### Is there a relevant Issue open for this?

resolves #30 
#### Are there any other relevant resources that should be reviewed as well?

N/A
#### Who would you like to review this?

/cc @sherl0cks @mdanter 
