### PR TITLE
removing images without a build_tool from the promotion process

### DIFF
--- a/roles/create-openshift-resources/tasks/create_app.yml
+++ b/roles/create-openshift-resources/tasks/create_app.yml
@@ -120,12 +120,17 @@
   failed_when: false
   changed_when: false
 
+- name: "Add App To Imagestream To Promote"
+  set_fact:
+    imagestreams_to_promote: "{{ [ app.name ] | union( imagestreams_to_promote ) }}" # simplest way I could find to append to a list. alternatives welcome
+  when: project.environment_type is defined and project.environment_type == 'build' and app.build_tool is defined and app.build_tool != 'none'
+
 # http://docs.ansible.com/ansible/playbooks_loops.html#loops-and-includes-in-2-0
 - name: Set Facts for promote_image.yml includes
   set_fact:
     app_name: "{{ app.name }}"
     project_name: "{{ project.name }}"
-  when: get_app_name_result.rc == 1 and project.environment_type is defined and project.environment_type == 'promotion'
+  when: get_app_name_result.rc == 1 and project.environment_type is defined and project.environment_type == 'promotion' and app.name in imagestreams_to_promote
 
 
 ## this is currently disabled until https://github.com/rht-labs/api-design/issues/28 is resolved
@@ -136,7 +141,7 @@
 #  when: get_app_name_result.rc == 1 and project.environment_type is defined and project.environment_type == true
 
 - include: promote_image_oc.yml
-  when: get_app_name_result.rc == 1 and project.environment_type is defined and project.environment_type == 'promotion'
+  when: get_app_name_result.rc == 1 and project.environment_type is defined and project.environment_type == 'promotion' and app.name in imagestreams_to_promote
 
 - name: "Create App: {{ app.name }}"
   command: >

--- a/roles/create-openshift-resources/tasks/create_project.yml
+++ b/roles/create-openshift-resources/tasks/create_project.yml
@@ -16,7 +16,7 @@
 
 - name: "Set Imagestream Fact For Build Environment"
   set_fact:
-    imagestream_names: []
+    imagestreams_to_promote: []
     build_project_name: "{{ project.name }}"
   when: project.environment_type is defined and project.environment_type == 'build'
 

--- a/roles/create-openshift-resources/tests/vars/automation_api.json
+++ b/roles/create-openshift-resources/tests/vars/automation_api.json
@@ -35,6 +35,15 @@
 										"route_type": "default"
 									}
 								]
+							},
+							{
+								"name": "automation-api-db",
+								"base_image": "openshift/postgresql",
+								"environment_variables": {
+									"POSTGRESQL_USER": "apidb",
+									"POSTGRESQL_PASSWORD": "apidb01",
+									"POSTGRESQL_DATABASE": "automation_api_dev"
+								}
 							}
 						],
 						"group_to_role": [
@@ -77,6 +86,28 @@
 												}
 											]
 										}
+									}
+								]
+							},
+							{
+								"name": "automation-api-db",
+								"base_image": "openshift/postgresql",
+								"environment_variables": {
+									"POSTGRESQL_USER": "apidb",
+									"POSTGRESQL_PASSWORD": "apidb01",
+									"POSTGRESQL_DATABASE": "automation_api_delivery"
+								},
+								"build_tool" : "none"
+							}
+						],
+						"group_to_role": [
+							{
+								"group": {
+									"name": "system:serviceaccounts"
+								},
+								"roles": [
+									{
+										"name": "view"
 									}
 								]
 							}


### PR DESCRIPTION
#### What does this PR do?

Add logic to prevent the playbook from attempting to promote images which do not have an associated imagestream in the source project. This common for database images, which do not have build config and therefore do not build and imagestream. We always want to deploy the imagestream from the openshift name spaces in these cases.
#### Which tests illustrate how this code works?

cdk_create_labs_automation_api
#### Is there a relevant Issue open for this?

resolves #48 
#### Are there any other relevant resources that should be reviewed as well?
#### Who would you like to review this?

/cc @oybed @mcanoy 
