### PR TITLE
adding support for hostname and port config for default routes

### DIFF
--- a/roles/create-openshift-resources/filter_plugins/networking_filters.py
+++ b/roles/create-openshift-resources/filter_plugins/networking_filters.py
@@ -13,13 +13,11 @@ def apply_ports_spec_config(deployment_config, application):
 def create_port_spec_for_deployment_config( application ):
     deployment_config_ports_spec = []
     for route in application['routes']:
-        # default routes should not have any further configuration
-        if route['route_type'] != 'default':   
-            for port_config in route['service']['ports']:
-                port_spec = {}
-                port_spec['containerPort'] = port_config['target_port']
-                port_spec['protocol'] = port_config['protocol']
-                deployment_config_ports_spec.append( port_spec )
+        for port_config in route['service']['ports']:
+            port_spec = {}
+            port_spec['containerPort'] = port_config['target_port']
+            port_spec['protocol'] = port_config['protocol']
+            deployment_config_ports_spec.append( port_spec )
     return deployment_config_ports_spec
 
 def modify_deployment_config_with_new_ports_spec( deployment_config, deployment_config_ports_spec ):
@@ -28,7 +26,7 @@ def modify_deployment_config_with_new_ports_spec( deployment_config, deployment_
     updated_deployment_config['spec']['template']['spec']['containers'][0]['ports'] = deployment_config_ports_spec
     return updated_deployment_config
 
-def to_create_route_options( route, app_name ):
+def create_secured_route_options( route, app_name ):
     options_string = ''
     if 'route_type' in route and route['route_type'] != '':
         options_string += '{} '.format( route['route_type'] )
@@ -45,12 +43,28 @@ def to_create_route_options( route, app_name ):
     
     return options_string
 
+def create_unsecured_route_options( route, app_name ):
+    options_string = ''
+    
+    # current API model does not have a service name, so we assume it's the same of the app.name
+    options_string += '{} '.format( app_name )
+    
+    if 'name' in route and route['name'] != '':
+        options_string += '--name {} '.format( route['name'] )
+    
+    if 'hostname' in route and route['hostname'] != '':
+        options_string += '--hostname {} '.format( route['hostname'] )
+    if 'port' in route and route['port'] != '':
+        options_string += '--port {} '.format( route['port'] )
+    
+    return options_string
 
 class FilterModule(object):
     ''' A filter to build a custom ports spec and optionally apply it to a deployment config  '''
     def filters(self):
         return {
             'apply_ports_spec_config': apply_ports_spec_config,
-            'to_create_route_options': to_create_route_options
+            'create_secured_route_options': create_secured_route_options,
+            'create_unsecured_route_options': create_unsecured_route_options
         }
 

--- a/roles/create-openshift-resources/tasks/configure_networking.yml
+++ b/roles/create-openshift-resources/tasks/configure_networking.yml
@@ -11,26 +11,38 @@
 # Long term, we should move this to oc patch which should solve avoid the race condition
 ##########################################
 
+# Right now this implementation only supports a single route.
+- name: Set Route Fact 
+  set_fact:
+    route: "{{ app.routes[0] }}"
+
+- name: "Set Facts for Update Ports"
+  set_fact:
+    update_to_service_required: true
+  when: route.service is defined
+
 - name: "Get Deployment Config: {{ app.name }}"
   command: >
     {{ openshift.common.client_binary }} get dc {{ app.name }} -n {{ project.name }} -o json
   register: dc_response
+  when: update_to_service_required is defined
   tags:
   - connected
 
 - name: Set Fact for DC object
   set_fact:
     dc: "{{ dc_response.stdout | from_json }}"
-
+  when: update_to_service_required is defined
 
 - name: Attempt to Apply New Port Specs to Deployment Config
   set_fact: 
     deployment_config:   "{{ dc | apply_ports_spec_config( app ) }}"
+  when: update_to_service_required is defined
 
 - name: Set Fact for Required Deployment Config Updates
   set_fact: 
     update_to_dc_required: true
-  when: deployment_config != dc
+  when: update_to_service_required is defined and deployment_config != dc
 
 - name: "Use a unique temporary file to store the Deployment Config object"
   command: mktemp
@@ -81,12 +93,6 @@
   tags:
   - connected
 
-# Right now this implementation only supports a single route.
-
-- name: Set Route Fact 
-  set_fact:
-    route: "{{ app.routes[0] }}"
-
 - name: "Determine If {{ app.name }} Route Exists"
   command: >
      {{ openshift.common.client_binary }} get route {{ app.name }} -n {{ project.name }} -o json
@@ -96,14 +102,14 @@
 
 - name: "Expose App with default route: {{ app.name }}"
   command: >
-    {{ openshift.common.client_binary }} expose service {{ app.name }} -n {{ project.name }}
+    {{ openshift.common.client_binary }} expose service {{ route | create_unsecured_route_options( app.name ) }} -n {{ project.name }}
   when: app_name_exists.rc == 1 and route.route_type is defined and route.route_type == 'default'
   tags:
   - connected
 
 - name: "Expose App with secured route: {{ app.name }}"
   command: >
-    {{ openshift.common.client_binary }} create route {{ route | to_create_route_options( app.name ) }} -n {{ project.name }}
+    {{ openshift.common.client_binary }} create route {{ route | create_secured_route_options( app.name ) }} -n {{ project.name }}
   when: app_name_exists.rc == 1 and route.route_type is defined and route.route_type in ['edge','reencrypt','passthrough']
   tags:
   - connected

--- a/roles/create-openshift-resources/tests/networking_test_default.yml
+++ b/roles/create-openshift-resources/tests/networking_test_default.yml
@@ -1,0 +1,30 @@
+---
+# This test covers the full feature set provided by the role
+
+- name: "Create test resources"
+  hosts: localhost
+
+  vars:
+    project:
+      name: pipeline-delivery
+
+  vars_files:
+  - vars/pipeline.json
+
+  pre_tasks:
+  - name: "Set Route Fact"
+    set_fact:
+      app: "{{ openshift_clusters[0].openshift_resources.projects[1].apps[0] }}"
+      route: "{{ openshift_clusters[0].openshift_resources.projects[1].apps[0].routes[0] }}"
+
+  roles:
+  - openshift-defaults
+
+  post_tasks:
+  - include: ../tasks/configure_networking.yml
+# cleanup
+  - name: "Remove project {{ item.name }}"
+    command: >
+      {{ openshift.common.client_binary }} delete project {{ item.name  }}
+    when: '"{{ item.name }}" != "ci" and cleanup is defined and cleanup'
+    with_items: '{{ openshift_resources.projects }}'

--- a/roles/create-openshift-resources/tests/vars/pipeline.json
+++ b/roles/create-openshift-resources/tests/vars/pipeline.json
@@ -16,7 +16,8 @@
 								"build_tool": "s2i",
 								"routes": [
 									{
-										"route_type": "default"
+										"route_type": "default",
+										"hostname": "pipeline.dev.rhel-cdk.10.1.2.2.xip.io"
 									}
 								]
 							}
@@ -30,9 +31,23 @@
 							{
 								"name": "jenkins",
 								"base_image": "jenkins",
+								"environment_variables": {
+									"JENKINS_OPTS": "'--httpPort=8081'"
+								},
 								"routes": [
 									{
-										"route_type": "default"
+										"route_type": "default",
+										"hostname": "pipeline.rhel-cdk.10.1.2.2.xip.io",
+										"port": "8081",
+										"service": {
+											"ports": [
+												{
+													"port": 8081,
+													"protocol": "TCP",
+													"target_port": 8081
+												}
+											]
+										}
 									}
 								]
 							}


### PR DESCRIPTION
#### What does this PR do?
- create options for `oc expose` using a custom filter plugin (I do love these plugins)
- enable `default` routes to configure port information
#### Which tests illustrate how this code works?

network_test_default.yml
cdk_create_pipeline.yml
#### Is there a relevant Issue open for this?

resolves #51 
#### Are there any other relevant resources that should be reviewed as well?
#### Who would you like to review this?

/cc @oybed 
