### PR TITLE
Change the way environment variables are passed to oc new-app

### DIFF
--- a/roles/create-openshift-resources/tasks/create_environment_variables_string.yml
+++ b/roles/create-openshift-resources/tasks/create_environment_variables_string.yml
@@ -1,13 +1,7 @@
 ---
-- name: "Set Base environment_variables_string"
-  set_fact:
-    environment_variables_string: '--env '
 
 - name: "Add variable to environment_variables_string"
   set_fact:
-    environment_variables_string: "{{ environment_variables_string }}{{ item }}={{ environment_variables[item] }},"
+    environment_variables_string: "{{ environment_variables_string }} -e '\"{{ item }}={{ environment_variables[item] }}\"' "
   with_items: '{{ environment_variables.keys() }}'
 
-- name: "Remove Trailing Comma from environment_variables_string"
-  set_fact:
-    environment_variables_string: "{{ environment_variables_string[:-1] }}"

--- a/roles/create-openshift-resources/tests/cdk_create_pipeline_ldap.yml
+++ b/roles/create-openshift-resources/tests/cdk_create_pipeline_ldap.yml
@@ -1,0 +1,27 @@
+---
+# This test covers the full feature set provided by the role
+# Adds ldap to the base pipeline test. The only difference here is that 
+# There are ldap vars set in the json. The need to be changed to a valid 
+# ldap server values to actually work
+
+- name: "Create test resources"
+  hosts: cdk
+
+  vars_files:
+    - vars/pipeline_ldap.json
+
+  vars:
+    openshift_password: admin
+    openshift_user: admin
+
+  roles:
+    - openshift-defaults
+    - create-openshift-resources
+
+# cleanup
+  post_tasks:
+  - name: "Remove project {{ item.name }}"
+    command: >
+      {{ openshift.common.client_binary }} delete project {{ item.name  }}
+    when: '"{{ item.name }}" != "ci" and cleanup is defined and cleanup'
+    with_items: '{{ openshift_resources.projects }}'

--- a/roles/create-openshift-resources/tests/vars/pipeline_ldap.json
+++ b/roles/create-openshift-resources/tests/vars/pipeline_ldap.json
@@ -1,0 +1,71 @@
+{
+	"openshift_clusters": [
+		{
+			"openshift_host_env": "10.1.2.2:8443",
+			"openshift_resources": {
+				"projects": [
+					{
+						"name": "pipeline-dev",
+						"display_name": "Pipeline - Dev",
+						"environment_type": "build",
+						"apps": [
+							{
+								"name": "jenkins",
+								"scm_url": "https://github.com/mcanoy/openshift-jenkins-s2i-config.git",
+								"scm_ref": "master",
+								"base_image": "openshift/jenkins",
+								"build_tool": "s2i",
+								"environment_variables": {
+									"LDAP_SERVER": "ldap://labs.redhat.com:389",
+									"LDAP_ROOT_DN": "dc=abc,dc=def,dc=ghi,dc=klmn,dc=redhat,dc=com",
+									"LDAP_USER_SEARCH_BASE": "",
+									"LDAP_USER_SEARCH": "(&(uid={0})(memberOf=cn=ad,cn=groups,cn=accounts,dc=abc,dc=def,dc=ghi,dc=jklm,dc=redhat,dc=com))",
+									"LDAP_GROUP_SEARCH_BASE": "",
+									"LDAP_MANAGER_DN": "uid=ldap_id,cn=users,cn=accounts,dc=abc,dc=def,dc=ghi,dc=jklm,dc=redhat,dc=com",
+									"LDAP_ACCESS": "fidelio",
+									"INHIBIT_INFER_ROOT_DN": true
+								},
+								"routes": [
+									{
+										"route_type": "default",
+										"hostname": "pipeline.dev.rhel-cdk.10.1.2.2.xip.io"
+									}
+								]
+							}
+						]
+					},
+					{
+						"name": "pipeline-delivery",
+						"display_name": "Pipeline - Delivery",
+						"environment_type": "promotion",
+						"apps": [
+							{
+								"name": "jenkins",
+								"base_image": "jenkins",
+								"environment_variables": {
+									"JENKINS_OPTS": "'--httpPort=8081'"
+								},
+								"routes": [
+									{
+										"route_type": "default",
+										"hostname": "pipeline.rhel-cdk.10.1.2.2.xip.io",
+										"port": "8081",
+										"service": {
+											"ports": [
+												{
+													"port": 8081,
+													"protocol": "TCP",
+													"target_port": 8081
+												}
+											]
+										}
+									}
+								]
+							}
+						]
+					}
+				]
+			}
+		}
+	]
+}


### PR DESCRIPTION
#### What does this PR do?

Closes #53 

Allows relatively unusual environmental variables to be passed to oc new-app 
ex. VAR_KEY=abc=def,ghi=jkl
This variable will now be passed in new-app

oc new-app ... -e '"VAR_KEY=abc=def,ghi=jkl"'
#### Which tests illustrate how this code works?

try cdk_create_pipeline_ldap.yml it's the same as cdk_create_pipeline.yml only with more ldap. Loads a different property file which has ldap settings. Those settings are faked so valid values will need to added to fully test.
#### Is there a relevant Issue open for this?
#53
#### Are there any other relevant resources that should be reviewed as well?

Requires https://github.com/rht-labs/openshift-jenkins-s2i-config/pull/12
#### Who would you like to review this?

/cc @sherl0cks @oybed 
