### PR TITLE
adding support to generate jenkins jobs

### DIFF
--- a/roles/create-openshift-resources/tasks/configure_jenkins_jobs.yml
+++ b/roles/create-openshift-resources/tasks/configure_jenkins_jobs.yml
@@ -1,0 +1,26 @@
+---
+- name: "Ensure the Pipeline Server is Up"
+  uri:
+    url: "{{ pipeline_server_url }}"
+    method: GET
+    status_code: 200 
+    user: "{{ pipeline_server_user }}"
+    password: "{{ pipeline_server_password }}"
+    force_basic_auth: yes
+  when: pipeline_server_url is defined and pipeline_server_url != ""
+  register: pipeline_server_check_result 
+  until: pipeline_server_check_result | success
+  retries: 24
+  delay: 5
+
+- name: "Generate Jobs Via Jenkins Seed Job"
+  uri:
+    url: "{{ pipeline_server_url }}/job/release-pipeline-seed-job-script/buildWithParameters?application_name={{ item }}&config_url={{ api_document_url }}&openshift_api_token={{ service_account_tokens[item] | replace(' ','') }}"
+    method: POST
+    status_code: 201
+    user: "{{ pipeline_server_user }}"
+    password: "{{ pipeline_server_password }}"
+    force_basic_auth: yes
+  when: service_account_tokens is defined and service_account_tokens | length > 0
+  with_items:
+  - "{{ service_account_tokens.keys() }}"

--- a/roles/create-openshift-resources/tasks/create_openshift_resources.yml
+++ b/roles/create-openshift-resources/tasks/create_openshift_resources.yml
@@ -23,3 +23,7 @@
     msg: "There were no projects set for your openshift_resources. This is key data for this role, so you may want to check that you do not have typo in the request."
   when: projects_present == false
 
+- name: "Configure Jenkins Jobs"
+  include: configure_jenkins_jobs.yml
+  static: no
+  when: pipeline_server_url is defined and pipeline_server_url != ""

--- a/roles/create-openshift-resources/tests/cdk_create_pipeline.yml
+++ b/roles/create-openshift-resources/tests/cdk_create_pipeline.yml
@@ -10,6 +10,9 @@
   vars:
     openshift_password: admin
     openshift_user: admin
+    pipeline_server_user: admin
+    pipeline_server_password: password
+    api_document_url: "https://raw.githubusercontent.com/rht-labs/ansible-stacks/master/roles/create-openshift-resources/tests/vars/pipeline.json"
 
   roles:
     - openshift-defaults

--- a/roles/create-openshift-resources/tests/configure_jenkins_jobs.yml
+++ b/roles/create-openshift-resources/tests/configure_jenkins_jobs.yml
@@ -1,0 +1,36 @@
+---
+# This test covers the full feature set provided by the role
+
+- name: "Create test resources"
+  hosts: localhost
+
+# given 
+  vars:
+    pipeline_server_url: http://pipeline.dev.rhel-cdk.10.1.2.2.xip.io
+    pipeline_server_user: admin
+    pipeline_server_password: password
+    api_document_url: https://raw.githubusercontent.com/rht-labs/ansible-stacks/master/roles/create-openshift-resources/tests/vars/pipeline.json
+    service_account_tokens: {}
+  # vars_files:
+  # - vars/automation_api.json
+
+  # pre_tasks:
+  # - name: "Set Route Fact"
+  #   set_fact:
+  #     app: "{{ openshift_clusters[0].openshift_resources.projects[0].apps[0] }}"
+
+  # roles:
+  # - openshift-defaults
+
+  post_tasks:
+# when  
+  - include: ../tasks/configure_jenkins_jobs.yml
+
+# then
+  # - name: "check if Service Account {{ service_account_name }} Exists"
+  #   command: >
+  #     {{ openshift.common.client_binary }} get sa {{ service_account_name }} -n {{ project.name }}
+  #   register: does_sa_exist  
+
+  # - assert:
+  #     that:

--- a/roles/create-openshift-resources/tests/vars/pipeline.json
+++ b/roles/create-openshift-resources/tests/vars/pipeline.json
@@ -1,4 +1,5 @@
 {
+	"pipeline_server_url" : "http://pipeline.rhel-cdk.10.1.2.2.xip.io",
 	"openshift_clusters": [
 		{
 			"openshift_host_env": "10.1.2.2:8443",


### PR DESCRIPTION
#### What does this PR do?
- Generates Jenkins jobs using our Jenkins seed job and the ansible-stacks generated service account tokens

#### Which tests illustrate how this code works?

- cdk_create_pipeline.yml
- configure_jenkins_jobs.yml

#### Is there a relevant Issue open for this?
#34 

#### Are there any other relevant resources that should be reviewed as well?
https://github.com/rht-labs/api-design/pull/57

#### Who would you like to review this?
/cc @oybed 
