### PR TITLE
Remove dependency on oadm so that we can run playbooks remotely

### DIFF
--- a/roles/openshift-defaults/defaults/main.yml
+++ b/roles/openshift-defaults/defaults/main.yml
@@ -2,7 +2,7 @@
 openshift:
   common:
     client_binary: "oc"
-    admin_binary: "oadm"
+    admin_binary: "oc adm"
 docker:
   common:
     client_binary: "docker"


### PR DESCRIPTION
#### What does this PR do?
Replaces `oadm`  with `oc adm` to allow for these playbook to be run from remote oc clients.

#### Which tests illustrate how this code works?
unsure

#### Is there a relevant Issue open for this?
n/a

#### Are there any other relevant resources that should be reviewed as well?
n/a

#### Who would you like to review this?
@oybed 

