### PR TITLE
create-identities - Add group member modification, add expiration dat…

### DIFF
--- a/roles/create-identities/README.md
+++ b/roles/create-identities/README.md
@@ -11,4 +11,5 @@ run the test ```ansible-playbook -i inventory create_idm.yml```
 
 * This requires that you have an existing idm available. The code is written expressly for and is tested against the idm provide by RHEL 7.2
 * change the value in the inventory file to point to a valid idm
+* You can test modfications by re-running the test pointing to a different json file ```ansible-playbook -i inventory create_idm.yml -e "@vars/idm_mod.json"
 

--- a/roles/create-identities/tasks/add_user_to_group.yml
+++ b/roles/create-identities/tasks/add_user_to_group.yml
@@ -1,10 +1,21 @@
 ---
-  - name: "Add Member to Group"
+  - name: "Init User List {{ this_group.name }}"
+    set_fact:
+      user_list: ''
+
+  - name: "Add Users to List {{ this_group.name }}"
+    set_fact:
+      user_list: "{{ user_list }}{{ item.user_name }},"
+    with_items: '{{ this_group.members | default([]) }}'
+
+  - name: "Remove Trailing Comma from User List  {{ this_group.name }}"
+    set_fact:
+      user_list: "{{ user_list[:-1] }}"
+    when: this_group.members is defined
+
+  - name: "Add Members to Group {{ this_group.name }}"
     ipa_group_membership:
       ipa_admin_user: "{{ ipa_admin_user }}"
       ipa_admin_password: "{{ ipa_admin_password }}"
-      cn: "{{ item.0.name }}"
-      uid: "{{ item.1.user_name }}"
-    with_subelements: 
-      - "{{ user_groups }}"
-      - members
+      cn: "{{ this_group.name }}"
+      uid: "{{ user_list }}"

--- a/roles/create-identities/tasks/create_user.yml
+++ b/roles/create-identities/tasks/create_user.yml
@@ -3,9 +3,10 @@
     ipa_user:
       ipa_admin_user: "{{ ipa_admin_user }}"
       ipa_admin_password: "{{ ipa_admin_password }}"
-      givenname: "{{ item.first_name }}"
-      sn: "{{ item.last_name }}"
+      givenname: "{{ item.first_name | default('Red') }}"
+      sn: "{{ item.last_name | default('Hat') }}"
       uid: "{{ item.user_name }}"
       password: "{{ item.user_name }}"
-      email: "{{ item.email }}"
+      email: "{{ item.email | default('') }}"
+      expiration_date: "{{ item.expiration_date | default('') }}"
     with_items: "{{ users }}"

--- a/roles/create-identities/tasks/main.yml
+++ b/roles/create-identities/tasks/main.yml
@@ -5,4 +5,7 @@
 - include: create_group.yml
 
 - include: add_user_to_group.yml
+  with_items: "{{ user_groups }}"
+  loop_control:
+    loop_var: "this_group"
 

--- a/roles/create-identities/tests/vars/idm_mod.json
+++ b/roles/create-identities/tests/vars/idm_mod.json
@@ -5,26 +5,24 @@
             "first_name": "Gord",
             "last_name": "Downie",
             "email": "gdownie@redhat.com",
-            "expiration_date": "2018-11-30T22:38:40.326Z"
+            "expiration_date": "2019-11-30T22:38:40.326Z"
+
         }, 
         { 
             "user_name": "lcohen", 
             "first_name": "Leonard",
             "last_name": "Cohen",
-            "email": "lcohen@redhat.com",
-            "expiration_date": "2018-11-30T22:38:40.326Z"
+            "email": "lcohen@redhat.com"
         }, 
         { 
             "user_name": "rhawkins",
             "first_name": "Ron",
             "last_name": "Hawkins",
-            "email": "rhawkins@redhat.com"
+            "email": "rhawkins@redhat.com",
+            "expiration_date": "2018-11-30T22:38:40.326Z"
         }, 
         { 
             "user_name": "wclark",
-            "first_name": "Wendel",
-            "last_name": "Clark",
-            "email": "wclark@redhat.com",
             "expiration_date": "2018-11-30T22:38:40.326Z"
         } 
     ],
@@ -34,20 +32,11 @@
             "members": [
                 { "user_name": "gdownie" }, 
                 { "user_name": "lcohen" }, 
-                { "user_name": "rhawkins" }
+                { "user_name": "wclark" }
             ]
         },
         {
-            "name": "test-group2",
-            "members": [
-                { "user_name": "rhawkins" }
-            ]
-        },
-        {
-            "name": "test-group3",
-            "members": [
-                { "user_name": "gdownie" }
-            ]
-          }
+            "name": "test-group2"
+        }
     ]
 }


### PR DESCRIPTION
#### What does this PR do?
In create-identities - Adds ability to modify (add/remove) users from a group. Adds ability to set an expiration_date for a user so that a user will no longer be able to login. 

#### Which tests illustrate how this code works?
roles/create-identities/tests/create_idm.yml. For a little more information see the README.md in roles/create-identities

#### Is there a relevant Issue open for this?
Resolves #69 

#### Are there any other relevant resources that should be reviewed as well?
A corresponding PR exists in automation-api https://github.com/rht-labs/automation-api/pull/23 

#### Who would you like to review this?
/cc @sherl0cks @oybed 

…e for users