### PR TITLE
When creating an app from a template, we want environment variables t…

### DIFF
--- a/roles/create-openshift-resources/tasks/create_environment_variables_string.yml
+++ b/roles/create-openshift-resources/tasks/create_environment_variables_string.yml
@@ -4,4 +4,10 @@
   set_fact:
     environment_variables_string: "{{ environment_variables_string }} -e '\"{{ item }}={{ environment_variables[item] }}\"' "
   with_items: '{{ environment_variables.keys() }}'
+  when: app.from_template is not defined and app.from_template == ''
 
+- name: "Add variable to environment_variables_string"
+  set_fact:
+    environment_variables_string: "{{ environment_variables_string }} -p '\"{{ item }}={{ environment_variables[item] }}\"' "
+  with_items: '{{ environment_variables.keys() }}'
+  when: app.from_template is defined and app.from_template != ''


### PR DESCRIPTION
…o be passed as template parameters (-p) rather than raw env vars (-e)

#### What does this PR do?
Normally we pass env vars as -e, but when instantiating a template, we instead want to pass env vars as -p so that they will be processed by the template.

#### Which tests illustrate how this code works?
n/a

#### Is there a relevant Issue open for this?

#### Are there any other relevant resources that should be reviewed as well?


#### Who would you like to review this?
/cc @sherl0cks  @oybed 
