### PR TITLE
Should be able to join pod networks when creating a project

### DIFF
--- a/roles/create-openshift-resources/tasks/create_project.yml
+++ b/roles/create-openshift-resources/tasks/create_project.yml
@@ -10,6 +10,7 @@
     persistent_volume_claims_def: ''
     apps_def: ''
     project: "{{ project_item }}"
+    pod_network_to_join: ''
 
 - name: Fail for Missing Project Name
   fail: msg="This role requires project.name to be set and non empty"
@@ -45,6 +46,11 @@
   set_fact:
     project_options: "{{ project_options }} --display-name='{{ project.display_name }}'"
   when: project.display_name is defined and project.display_name != ''
+
+- name: "Set pod network to join"
+  set_fact:
+    pod_network_to_join: "{{ project.join_pod_network }}"
+  when: project.join_pod_network is defined and project.join_pod_network != ''
 
 - name: "Determine If {{ project.name }} Project Exists"
   command: >
@@ -85,6 +91,12 @@
     loop_var: app_item
   when: apps_def != ''
   static: no
+
+- name: "Join Pod Networks"
+  command: >
+    {{ openshift.common.admin_binary }} pod-network join-projects --to={{ pod_network_to_join }} {{ project.name }}
+  when: pod_network_to_join != '' and project.name !=''
+
 
 ## In order to increase performance when more than one app is present in a build env, this check was moved here after create_app.yml so that builds and image pushes can execute in parallel.
 

--- a/roles/create-openshift-resources/tests/vars/openshift_resources.json
+++ b/roles/create-openshift-resources/tests/vars/openshift_resources.json
@@ -14,13 +14,15 @@
               {
                 "name": "infographic-node-app",
                 "scm_url": "https://github.com/rht-labs/infographic-node-app.git",
-                "base_image": "openshift/nodejs"
+                "base_image": "openshift/nodejs",
+                "build_tool": "s2i"
               },
               {
                 "name": "infographic",
                 "scm_url": "https://github.com/rht-labs/infographic.git",
                 "context_dir": "website",
-                "base_image": "openshift/php"
+                "base_image": "openshift/php",
+                "build_tool": "s2i"
               }
             ],
             "user_to_role": [
@@ -70,6 +72,7 @@
             "name": "template-test",
             "display_name": "Test app creation from template",
             "environment_type": "test",
+            "join_pod_network": "ci-dev",
             "apps": [
               {
                 "name": "nodejs",


### PR DESCRIPTION
#### What does this PR do?
When running OpenShift with multitenancy enabled, it is often required to enable services within different projects to talk to eachother. This feature adds a field to the api model to tell ansible whether or not to join a project to another project:

```
openshift_clusters:
- openshift_host_env: 10.1.2.2:8443
  openshift_resources:
    projects:
    - name: sample-project
      display_name: Sample Project
      environment_type: build
      join_pod_network: some-other-project
      apps:
```

#### Which tests illustrate how this code works?
We need to talk about how to write a test for this one, as the cdk cannot have multi-tenant enabled.

#### Is there a relevant Issue open for this?
n/a

#### Are there any other relevant resources that should be reviewed as well?
https://docs.openshift.com/container-platform/3.3/install_config/configuring_sdn.html#migrating-between-sdn-plugins
https://docs.openshift.com/container-platform/3.3/admin_guide/managing_pods.html#joining-project-networks

#### Who would you like to review this?
/cc @oybed @sherl0cks 
