### PR TITLE
New oc syntax

### DIFF
--- a/roles/create-openshift-resources/filter_plugins/general_filters.py
+++ b/roles/create-openshift-resources/filter_plugins/general_filters.py
@@ -15,10 +15,10 @@ def create_param_string(key_value_pairs):
     pairs = []
     string = ""
     for key in key_value_pairs:
-        pair = key + '=' + key_value_pairs[key]
+        pair = "\"{}={}\"".format(key, key_value_pairs[key])
         pairs.append(pair)
     for i, pair in enumerate(pairs):
-        string += ' -p ' + pair
+        string += " -p {}".format(pair)
     return string
 
 
@@ -26,10 +26,10 @@ def create_env_string(key_value_pairs):
     pairs = []
     string = ""
     for key in key_value_pairs:
-        pair = "\"" + key + '=' + key_value_pairs[key] + "\""
+        pair = "\"{}={}\"".format(key, key_value_pairs[key])
         pairs.append(pair)
     for i, pair in enumerate(pairs):
-        string += ' -e ' + pair
+        string += " -e {}".format(pair)
     return string
 
 

--- a/roles/create-openshift-resources/filter_plugins/general_filters.py
+++ b/roles/create-openshift-resources/filter_plugins/general_filters.py
@@ -10,9 +10,21 @@ def create_key_value_pairs_string(key_value_pairs):
             string += ','
     return string
 
+def create_param_string(key_value_pairs):
+    pairs = []
+    string = ""
+    for key in key_value_pairs:
+        pair = key + '=' + key_value_pairs[key]
+        pairs.append(pair)
+    for i, pair in enumerate(pairs):
+        string += '-p ' + pair
+    return string
+
+
 class FilterModule(object):
     ''' A set of general filters to support OpenShift CLI'''
     def filters(self):
         return {
-            'key_value_pairs_string': create_key_value_pairs_string
+            'key_value_pairs_string': create_key_value_pairs_string,
+            'param_string' : create_param_string
         }

--- a/roles/create-openshift-resources/filter_plugins/general_filters.py
+++ b/roles/create-openshift-resources/filter_plugins/general_filters.py
@@ -10,6 +10,7 @@ def create_key_value_pairs_string(key_value_pairs):
             string += ','
     return string
 
+
 def create_param_string(key_value_pairs):
     pairs = []
     string = ""
@@ -17,14 +18,26 @@ def create_param_string(key_value_pairs):
         pair = key + '=' + key_value_pairs[key]
         pairs.append(pair)
     for i, pair in enumerate(pairs):
-        string += '-p ' + pair
+        string += ' -p ' + pair
+    return string
+
+
+def create_env_string(key_value_pairs):
+    pairs = []
+    string = ""
+    for key in key_value_pairs:
+        pair = key + '=' + key_value_pairs[key]
+        pairs.append(pair)
+    for i, pair in enumerate(pairs):
+        string += ' -e ' + pair
     return string
 
 
 class FilterModule(object):
-    ''' A set of general filters to support OpenShift CLI'''
+    ''' A set of general filters to support OpenShift CLI '''
     def filters(self):
         return {
             'key_value_pairs_string': create_key_value_pairs_string,
-            'param_string' : create_param_string
+            'oc_param_string': create_param_string,
+            'oc_env_string': create_env_string
         }

--- a/roles/create-openshift-resources/filter_plugins/general_filters.py
+++ b/roles/create-openshift-resources/filter_plugins/general_filters.py
@@ -26,7 +26,7 @@ def create_env_string(key_value_pairs):
     pairs = []
     string = ""
     for key in key_value_pairs:
-        pair = key + '=' + key_value_pairs[key]
+        pair = "\"" + key + '=' + key_value_pairs[key] + "\""
         pairs.append(pair)
     for i, pair in enumerate(pairs):
         string += ' -e ' + pair

--- a/roles/create-openshift-resources/tasks/create_app.yml
+++ b/roles/create-openshift-resources/tasks/create_app.yml
@@ -22,8 +22,6 @@
     app_source: ''
     app_scm: ''
     labels: ''
-    environment_variables: ''
-    environment_variables_string: ''
     pvc_associations_def: ''
     fabric8_java_s2i_present: false
     routes_present: false
@@ -81,20 +79,13 @@
 
 
 
-- name: "Set Environment_Variables Fact"
+- name: "Add app.environment_variables to app_options"
   set_fact:
-    environment_variables: "{{ app.environment_variables }}"
-  when: app.environment_variables is defined and app.environment_variables != '' and app.environment_variables|length > 0
-
-# http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes
-- include: create_environment_variables_string.yml
-  when: environment_variables is defined and environment_variables != ''
-  static: no
-
-- name: "Add environment_variables_string to app_options"
-  set_fact:
-    app_options: "{{ app_options }} {{ environment_variables_string }}"
-  when: environment_variables_string is defined and environment_variables_string != ''
+    app_options: "{{ app_options }} {{ app.environment_variables | oc_env_string }}"
+  when:
+  - app.environment_variables is defined
+  - app.environment_variables != ''
+  - app.environment_variables|length > 0
 
 
 - name: "Set Fact for Fabric Java S2I"

--- a/roles/create-openshift-resources/tasks/create_environment_variables_string.yml
+++ b/roles/create-openshift-resources/tasks/create_environment_variables_string.yml
@@ -1,7 +1,0 @@
----
-
-- name: "Add variable to environment_variables_string"
-  set_fact:
-    environment_variables_string: "{{ environment_variables_string }} -e '\"{{ item }}={{ environment_variables[item] }}\"' "
-  with_items: '{{ environment_variables.keys() }}'
-

--- a/roles/create-openshift-resources/tasks/create_templates.yml
+++ b/roles/create-openshift-resources/tasks/create_templates.yml
@@ -25,7 +25,7 @@
 
 - name: "Apply {{ template.name }} Template with Parameters"
   command: >
-     {{ openshift.common.client_binary }} new-app --template {{ template.name }} -p {{ template.parameters | key_value_pairs_string }} -l pbiTemplateName={{ template.name  }} -n {{ project.name }}
+     {{ openshift.common.client_binary }} new-app --template {{ template.name }} {{ template.parameters | param_string }} -l pbiTemplateName={{ template.name  }} -n {{ project.name }}
   when: oc_response_object_count == "0" and template.parameters is defined and template.parameters | length > 0
 
 - name: "Apply {{ template.name }} Template without Parameters"

--- a/roles/create-openshift-resources/tasks/create_templates.yml
+++ b/roles/create-openshift-resources/tasks/create_templates.yml
@@ -25,7 +25,7 @@
 
 - name: "Apply {{ template.name }} Template with Parameters"
   command: >
-     {{ openshift.common.client_binary }} new-app --template {{ template.name }} {{ template.parameters | param_string }} -l pbiTemplateName={{ template.name  }} -n {{ project.name }}
+     {{ openshift.common.client_binary }} new-app --template {{ template.name }} {{ template.parameters | oc_param_string }} -l pbiTemplateName={{ template.name  }} -n {{ project.name }}
   when: oc_response_object_count == "0" and template.parameters is defined and template.parameters | length > 0
 
 - name: "Apply {{ template.name }} Template without Parameters"

--- a/roles/create-openshift-resources/tests/plays/jenkins_templates_test.yml
+++ b/roles/create-openshift-resources/tests/plays/jenkins_templates_test.yml
@@ -21,24 +21,24 @@
         oc new-project {{ item }}
       ignore_errors: yes
       with_items:
-        - 'template-uat'
-        - 'template-dev'
+        - 'template-uat-ci'
+        - 'template-dev-ci'
 
     - name: "Install Jenkins S2I Template in {{ item }}"
       command: >
         oc create -f https://raw.githubusercontent.com/sherl0cks/examples/jenkins-ocp-templates/jenkins-ocp-templates/jenkins-s2i-template.json -n {{ item }}
       ignore_errors: yes
       with_items:
-        - 'template-uat'
-        - 'template-dev'
+        - 'template-uat-ci'
+        - 'template-dev-ci'
 
     - name: "Install Jenkins Ephemeral Template in {{ item }}"
       command: >
         oc create -f https://raw.githubusercontent.com/openshift/origin/release-1.3/examples/jenkins/jenkins-ephemeral-template.json -n {{ item }}
       ignore_errors: yes
       with_items:
-        - 'template-uat'
-        - 'template-dev'
+        - 'template-uat-ci'
+        - 'template-dev-ci'
 
 
   roles:

--- a/roles/create-openshift-resources/tests/plays/vars/automation_api.json
+++ b/roles/create-openshift-resources/tests/plays/vars/automation_api.json
@@ -6,8 +6,7 @@
       "openshift_resources": {
         "projects": [
           {
-            "name": "labs-api-dev",
-            "display_name": "Labs API - Dev",
+            "name": "labs-api-dev-ci",
             "environment_type": "build",
             "apps": [
               {
@@ -25,7 +24,8 @@
                   "POSTGRESQL_SVC": "postgresql.labs-api-dev.svc.cluster.local",
                   "POSTGRESQL_USER": "autoautoauto",
                   "POSTGRESQL_PASSWORD": "password",
-                  "POSTGRESQL_DATABASE": "automation"
+                  "POSTGRESQL_DATABASE": "automation",
+                  "FOO" : "this is a test for make sure env vars like JAVA_OPTS work with quotes"
                 },
                 "routes": [
                   {

--- a/roles/create-openshift-resources/tests/plays/vars/automation_api.json
+++ b/roles/create-openshift-resources/tests/plays/vars/automation_api.json
@@ -25,7 +25,8 @@
                   "POSTGRESQL_USER": "autoautoauto",
                   "POSTGRESQL_PASSWORD": "password",
                   "POSTGRESQL_DATABASE": "automation",
-                  "FOO" : "this is a test for make sure env vars like JAVA_OPTS work with quotes"
+                  "FOO" : "this is a test for make sure env vars like JAVA_OPTS work with quotes",
+                  "BAR" : true
                 },
                 "routes": [
                   {

--- a/roles/create-openshift-resources/tests/plays/vars/infographic.json
+++ b/roles/create-openshift-resources/tests/plays/vars/infographic.json
@@ -7,7 +7,7 @@
       "openshift_resources": {
         "projects": [
           {
-            "name": "infographic-dev",
+            "name": "infographic-dev-ci",
             "environment_type": "build",
             "apps": [
               {

--- a/roles/create-openshift-resources/tests/plays/vars/jenkins_templates.json
+++ b/roles/create-openshift-resources/tests/plays/vars/jenkins_templates.json
@@ -6,8 +6,7 @@
       "openshift_resources": {
         "projects": [
           {
-            "name": "template-dev",
-            "display_name": "Jenkins Template - Dev",
+            "name": "template-dev-ci",
             "environment_type": "build",
             "templates": [
               {

--- a/roles/create-openshift-resources/tests/plays/vars/jenkins_templates.json
+++ b/roles/create-openshift-resources/tests/plays/vars/jenkins_templates.json
@@ -35,7 +35,7 @@
             ]
           },
           {
-            "name": "template-uat",
+            "name": "template-uat-ci",
             "display_name": "Jenkins Template - UAT",
             "environment_type": "promotion",
             "templates": [

--- a/roles/create-openshift-resources/tests/plays/vars/jenkins_templates.json
+++ b/roles/create-openshift-resources/tests/plays/vars/jenkins_templates.json
@@ -13,8 +13,8 @@
               {
                 "name": "jenkins-s2i",
                 "parameters": {
-                  "SOURCE_REPOSITORY_URL": "https://github.com/sherl0cks/openshift-jenkins-s2i-config.git",
-                  "SOURCE_REPOSITORY_REF": "jenkins-2",
+                  "SOURCE_REPOSITORY_URL": "https://github.com/rht-labs/openshift-jenkins-s2i-config.git",
+                  "SOURCE_REPOSITORY_REF": "master",
                   "NAME": "jenkins"
                 }
               },


### PR DESCRIPTION
#### What does this PR do?
Updates syntax for template params and app env vars to be valid for both 3.3 and 3.4 `oc`.  Tested against s3 cluster with oc versions:
- v3.4.1.7
- v3.3.1.14

As a mental note, any CI we build should run against all `oc` versions we support.

#### Which tests illustrate how this code works?
existing `jenkins_templates_test.yml` and `automation_api_test.yml` test provide regression.

#### Is there a relevant Issue open for this?
resolves #100 

#### Are there any other relevant resources that should be reviewed as well?
nope

#### Who would you like to review this?
/cc @oybed 
